### PR TITLE
更新福建省内的电台媒体信息

### DIFF
--- a/docs/如何怎样/radio.html
+++ b/docs/如何怎样/radio.html
@@ -257,7 +257,7 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
                     </tr>
                     <!---->
                     <tr>
-                        <td rowspan="4">漳州市</td>
+                        <td rowspan="5">漳州市</td>
                         <td>FM96.2 / <span title="云霄县转播">FM89.6</span> 漳州综合广播</td>
                         <td>部分闽南语</td>
                         <td><a href="https://www.radio.cn/pc-portal/erji/radioStation.html" target="_blank">云听</a> / <a href="https://www.qtfm.cn/radios/1742" target="_blank">蜻蜓 FM</a></td>
@@ -276,6 +276,16 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
                         <td>FM92.5 云霄人民广播电台</td>
                         <td>微信公众号“云霄融媒”</td>
                         <td><a href="https://www.qtfm.cn/radios/20500106" target="_blank">蜻蜓 FM</a></td>
+                    </tr>
+                    <tr>
+                        <td>南靖县</td>
+                        <td>
+                            我试了下看视频，提示找不到对应的 IP 地址；<br>
+                            网站证书两年前过期，但可以查到 ICP 备案；<br>
+                            可以读《南靖乡讯》；<br>
+                            微信公众号“南靖之窗”
+                        </td>
+                        <td><a href="https://www.fjnjnews.cn/index.htm" target="_blank">南靖新闻网</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/docs/如何怎样/radio.html
+++ b/docs/如何怎样/radio.html
@@ -182,7 +182,7 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
                     </tr>
                     <tr>
                         <td>FM100.7 福建交通广播</td>
-                        <td>五一台庆，<span title="2026年">今年</span> 28 周年，1007 邀您领旗</td>
+                        <td></td>
                     </tr>
                     <tr>
                         <td>FM98.7 福建都市广播 / 私家车广播 / 都市生活广播</td>
@@ -197,7 +197,12 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
                     </tr>
                     <tr>
                         <td>FM107 <del><a href="https://www.xmtv.cn/xmtv/2024-12-23/60bd158815a8dc55.html" target="_blank">厦门经济交通广播</a></del> / 交通旅游广播</td>
-                        <td>一起“厦乡趣（下乡去）”</td>
+                        <td>
+                            各个主播有自己的号，比如
+                            <ul>
+                                <li>子龙：微信视频号“开麦了子龙”，讲中年人生感悟，放歌/广告时直播会聊</li>
+                            </ul>
+                        </td>
                     </tr>
                     <tr>
                         <td>FM90.9 音乐广播</td>


### PR DESCRIPTION
南靖那个严格来说可能不算电台，应该算电视/报纸。

更多关于南靖县广播电视台的信息可以参考[百度百科](https://baike.baidu.com/item/%E5%8D%97%E9%9D%96%E5%8E%BF%E5%B9%BF%E6%92%AD%E7%94%B5%E8%A7%86%E5%8F%B0)。

---

福建 1007 那个删掉是因为台庆结束了，视频号可以看台庆经过。

---

厦门 107 那个...

“我们不说xxx，我们说...”